### PR TITLE
Fix bug in setting training data for ExactGP.

### DIFF
--- a/gpytorch/models/exact_gp.py
+++ b/gpytorch/models/exact_gp.py
@@ -50,15 +50,17 @@ class ExactGP(GP):
             if torch.is_tensor(inputs):
                 inputs = (inputs,)
             inputs = tuple(input_.unsqueeze(-1) if input_.ndimension() == 1 else input_ for input_ in inputs)
-            for input, t_input in zip(inputs, self.train_inputs):
-                for attr in {"shape", "dtype", "device"}:
-                    if strict and getattr(input, attr) != getattr(t_input, attr):
-                        raise RuntimeError("Cannot modify {attr} of inputs".format(attr=attr))
+            if strict:
+                for input, t_input in zip(inputs, self.train_inputs):
+                    for attr in {"shape", "dtype", "device"}:
+                        if getattr(input, attr) != getattr(t_input, attr):
+                            raise RuntimeError("Cannot modify {attr} of inputs".format(attr=attr))
             self.train_inputs = inputs
         if targets is not None:
-            for attr in {"shape", "dtype", "device"}:
-                if strict and getattr(targets, attr) != getattr(self.train_targets, attr):
-                    raise RuntimeError("Cannot modify {attr} of targets".format(attr=attr))
+            if strict:
+                for attr in {"shape", "dtype", "device"}:
+                    if getattr(targets, attr) != getattr(self.train_targets, attr):
+                        raise RuntimeError("Cannot modify {attr} of targets".format(attr=attr))
             self.train_targets = targets
         self.prediction_strategy = None
 


### PR DESCRIPTION
It appears valid for a GP to have its training inputs/labels set to `None`. However, if you call `set_train_data` when the current training inputs are `None`, you'll get an error at `for input, t_input in zip(inputs, self.train_inputs)` (because `None` is not iterable and thus can't be `zip`ped). This PR moves the check for `if strict` up so that, if `strict == False`, the entire checking section is skipped and it doesn't matter whether the training data was `None` or not.

When `strict == True`, the behavior remains unchanged. However, it might be good, if the current training inputs are `None`, to raise a more useful error than the one that `zip` will throw. I wasn't sure, though, if the current `RuntimeError` that is normally raised quite fits this case (do you want to say `"Cannot modify shape of inputs"` when the current inputs don't actually have a defined shape?). Let me know if you want me to push a quick commit with a different message for the special case of the current inputs being `None`.

On thinking about it, I'll add a commit now to improve the error message a bit here and document what `strict` does (I just came to the source code to find out that I needed to set `strict = False` for some of my updates). I'll go ahead and make sure the `None` case gets to the usual error message, then we can update later if wanted. Hold on a sec.